### PR TITLE
Feature/settable dockercompose vars

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,21 @@
+.env
+
+### macOS ###
 .DS_Store
+
+### Emacs ###
+# -*- mode: gitignore; -*-
+*~
+\#*\#
+
+# directory configuration
+.dir-locals.el
+
+
+### Vim ###
+# Swap
+[._]*.s[a-v][a-z]
+[._]*.sw[a-p]
+[._]s[a-rt-v][a-z]
+[._]ss[a-gi-z]
+[._]sw[a-p]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,15 +6,14 @@ services:
       context: .
       network: 'host'
     ports:
-      - 1935:1935
-      - 80:80
-      - 443:443
+      - ${RTMP_PORT:-1935}:1935
+      - ${HTTP_PORT:-80}:80
     environment:
       - HTTP_PORT=80
       - RTMP_PORT=1935
 
       # set a custom auth token here
-      - RTMP_AUTH_TOKEN=
+      - RTMP_AUTH_TOKEN=${RTMP_AUTH_TOKEN:-}
 
       # set custom ffmpeg flags here
       #
@@ -35,7 +34,7 @@ services:
     command: /run-tests.sh
     environment:
       # must match auth token above
-      - RTMP_AUTH_TOKEN=
+      - RTMP_AUTH_TOKEN=${RTMP_AUTH_TOKEN:-}
     depends_on:
       - nginx-rtmp
     networks:


### PR DESCRIPTION
as discussed in #1, this makes the exposed ports (RTMP/HTTP) configurable via `.env`

this PR also updates the `.gitignore` file to exclude temporary files from popular editors (vi, emacs).
in addition it also gitignores the `.env` file (as this is likely to be very site-specific)

(sorry for taking so long to commit this trivial fixes. i'm back from :beach_umbrella: )

Closes: #1
Closes: #2 