### PR TITLE
Rate limiting

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,11 +126,13 @@ DASH stream webtools are available under http://localhost/webtools
 
 ### RTMP Authentication ###
 
-To add a RTMP auth secret token you can update the "RTMP_AUTH_TOKEN" environment variable in the docker-compose.yml file, e.g. ```- RTMP_AUTH_TOKEN=my_secret```. 
+To add a RTMP auth secret token you can update the "RTMP_AUTH_TOKEN" environment variable in the docker-compose.yml or .env file, e.g. ```- RTMP_AUTH_TOKEN=my_secret```.
 
-To use a custom auth server you can update the "RTMP_AUTH_URL" environment variable. Earshot will pass ```name``` (the Stream Key), ```token``` (the auth token provided by the user), and other parameters to your server. 
+In order to prevent brute force attacks, Earshot will limit authentication requests to 1 per second.
 
-On your streaming client, appent the secret using the ```token``` GET parameter to the request. 
+To use a custom http auth server, you can update the `RTMP_AUTH_URL` environment variable. Earshot will pass ```name``` (the Stream Key), ```token``` (the auth token provided by the user), and other parameters to your server. You can read the [full list of parameters](https://github.com/arut/nginx-rtmp-module/wiki/Directives#on_play).
+
+On your streaming client, appent the secret using the ```token``` GET parameter to the request.
 
 * With ffmpeg: ```ffmpeg -y -stream_loop -1 -i tester/resources/16chambixloop.wav -af "channelmap=channel_layout=hexadecagonal" -c:a aac -ac 16 -b:a 2048k -f flv "rtmp://127.0.0.1:1935/live/stream1?token=my_secret"```
 * With OBS: your **Stream Key** should be appended with ```?token=my_secret```. If the stream name is stream1, Stream Key should be ```stream1?token=my_secret```

--- a/README.md
+++ b/README.md
@@ -128,7 +128,7 @@ DASH stream webtools are available under http://localhost/webtools
 
 To add a RTMP auth secret token you can update the "RTMP_AUTH_TOKEN" environment variable in the docker-compose.yml or .env file, e.g. ```- RTMP_AUTH_TOKEN=my_secret```.
 
-In order to prevent brute force attacks, Earshot will limit authentication requests to 1 per second.
+In order to prevent brute force attacks, Earshot will limit authentication requests to one per second. To allow for flexibility and legitimate traffic surges, occasional bursts for up to two requests are accepted, until, on avarage, the one per second limit is retained.
 
 To use a custom http auth server, you can update the `RTMP_AUTH_URL` environment variable. Earshot will pass ```name``` (the Stream Key), ```token``` (the auth token provided by the user), and other parameters to your server. You can read the [full list of parameters](https://github.com/arut/nginx-rtmp-module/wiki/Directives#on_play).
 

--- a/nginx-transcoder/nginx-no-ssl.conf
+++ b/nginx-transcoder/nginx-no-ssl.conf
@@ -28,7 +28,7 @@ http {
     include mime.types;
     sendfile on;
 
-    limit_req_zone $arg_addr zone=antiBruteForce:100k rate=1r/m;
+    limit_req_zone $arg_addr zone=antiBruteForce:100k rate=1r/s;
     limit_req_status 401;
 
     server {

--- a/nginx-transcoder/nginx-no-ssl.conf
+++ b/nginx-transcoder/nginx-no-ssl.conf
@@ -4,18 +4,17 @@ error_log /dev/stdout info;
 
 user nginx;
 
-limit_req_zone $binary_remote_addr zone=antiBruteForce:1m rate=1r/s;
-
 events {
     worker_connections 1024;
 }
 
 rtmp {
+    limit_req_zone $binary_remote_addr zone=antiBruteForce:1m rate=1r/s;
     server {
         listen ${RTMP_PORT};
         chunk_size 4000;
         notify_method get;
-        limit_req zone=antiBruteForce;
+        limit_req zone=antiBruteForce burst=2 nodelay;
 
         application live {
             live on;

--- a/nginx-transcoder/nginx-no-ssl.conf
+++ b/nginx-transcoder/nginx-no-ssl.conf
@@ -29,6 +29,7 @@ http {
     sendfile on;
 
     limit_req_zone $arg_addr zone=antiBruteForce:100k rate=1r/s;
+    limit_req_status 401;
 
     server {
         listen ${HTTP_PORT};

--- a/nginx-transcoder/nginx-no-ssl.conf
+++ b/nginx-transcoder/nginx-no-ssl.conf
@@ -28,7 +28,7 @@ http {
     include mime.types;
     sendfile on;
 
-    limit_req_zone $arg_addr zone=antiBruteForce:1m rate=1r/s;
+    limit_req_zone $arg_addr zone=antiBruteForce:100k rate=1r/s;
 
     server {
         listen ${HTTP_PORT};

--- a/nginx-transcoder/nginx-no-ssl.conf
+++ b/nginx-transcoder/nginx-no-ssl.conf
@@ -4,7 +4,7 @@ error_log /dev/stdout info;
 
 user nginx;
 
-limit_req_zone $binary_remote_addr zone=antiBruteForce:10m rate=1r/s;
+limit_req_zone $binary_remote_addr zone=antiBruteForce:1m rate=1r/s;
 
 events {
     worker_connections 1024;

--- a/nginx-transcoder/nginx-no-ssl.conf
+++ b/nginx-transcoder/nginx-no-ssl.conf
@@ -4,6 +4,8 @@ error_log /dev/stdout info;
 
 user nginx;
 
+limit_req_zone $binary_remote_addr zone=antiBruteForce:10m rate=1r/s;
+
 events {
     worker_connections 1024;
 }
@@ -13,6 +15,7 @@ rtmp {
         listen ${RTMP_PORT};
         chunk_size 4000;
         notify_method get;
+        limit_req zone=antiBruteForce;
 
         application live {
             live on;

--- a/nginx-transcoder/nginx-no-ssl.conf
+++ b/nginx-transcoder/nginx-no-ssl.conf
@@ -9,12 +9,10 @@ events {
 }
 
 rtmp {
-    limit_req_zone $binary_remote_addr zone=antiBruteForce:1m rate=1r/s;
     server {
         listen ${RTMP_PORT};
         chunk_size 4000;
         notify_method get;
-        limit_req zone=antiBruteForce burst=2 nodelay;
 
         application live {
             live on;
@@ -29,6 +27,8 @@ http {
 
     include mime.types;
     sendfile on;
+
+    limit_req_zone $arg_addr zone=antiBruteForce:1m rate=1r/s;
 
     server {
         listen ${HTTP_PORT};
@@ -93,6 +93,7 @@ http {
 
         #forward to custom rtmp auth url
         location /route_to_auth {
+            limit_req zone=antiBruteForce burst=2 nodelay;
             allow 127.0.0.1;
             deny all;
             proxy_pass  ${RTMP_AUTH_URL};

--- a/nginx-transcoder/nginx-no-ssl.conf
+++ b/nginx-transcoder/nginx-no-ssl.conf
@@ -28,7 +28,7 @@ http {
     include mime.types;
     sendfile on;
 
-    limit_req_zone $arg_addr zone=antiBruteForce:100k rate=1r/s;
+    limit_req_zone $arg_addr zone=antiBruteForce:100k rate=1r/m;
     limit_req_status 401;
 
     server {

--- a/nginx-transcoder/nginx.conf
+++ b/nginx-transcoder/nginx.conf
@@ -34,6 +34,7 @@ http {
     sendfile on;
 
     limit_req_zone $arg_addr zone=antiBruteForce:100k rate=1r/s;
+    limit_req_status 401;
 
     server {
         listen ${HTTP_PORT};

--- a/nginx-transcoder/nginx.conf
+++ b/nginx-transcoder/nginx.conf
@@ -33,7 +33,7 @@ http {
     include mime.types;
     sendfile on;
 
-    limit_req_zone $arg_addr zone=antiBruteForce:1m rate=1r/s;
+    limit_req_zone $arg_addr zone=antiBruteForce:100k rate=1r/s;
 
     server {
         listen ${HTTP_PORT};

--- a/nginx-transcoder/nginx.conf
+++ b/nginx-transcoder/nginx.conf
@@ -4,18 +4,17 @@ error_log /dev/stdout info;
 
 user nginx;
 
-limit_req_zone $binary_remote_addr zone=antiBruteForce:1m rate=1r/s;
-
 events {
     worker_connections 1024;
 }
 
 rtmp {
+    limit_req_zone $binary_remote_addr zone=antiBruteForce:1m rate=1r/s;
     server {
         listen ${RTMP_PORT};
         chunk_size 4000;
         notify_method get;
-        limit_req zone=antiBruteForce;
+        limit_req zone=antiBruteForce burst=2 nodelay;
 
         application live {
             live on;

--- a/nginx-transcoder/nginx.conf
+++ b/nginx-transcoder/nginx.conf
@@ -4,7 +4,7 @@ error_log /dev/stdout info;
 
 user nginx;
 
-limit_req_zone $binary_remote_addr zone=antiBruteForce:10m rate=1r/s;
+limit_req_zone $binary_remote_addr zone=antiBruteForce:1m rate=1r/s;
 
 events {
     worker_connections 1024;

--- a/nginx-transcoder/nginx.conf
+++ b/nginx-transcoder/nginx.conf
@@ -9,12 +9,10 @@ events {
 }
 
 rtmp {
-    limit_req_zone $binary_remote_addr zone=antiBruteForce:1m rate=1r/s;
     server {
         listen ${RTMP_PORT};
         chunk_size 4000;
         notify_method get;
-        limit_req zone=antiBruteForce burst=2 nodelay;
 
         application live {
             live on;
@@ -34,6 +32,8 @@ http {
 
     include mime.types;
     sendfile on;
+
+    limit_req_zone $arg_addr zone=antiBruteForce:1m rate=1r/s;
 
     server {
         listen ${HTTP_PORT};
@@ -109,6 +109,7 @@ http {
 
         #forward to custom rtmp auth url
         location /route_to_auth {
+            limit_req zone=antiBruteForce burst=2 nodelay;
             allow 127.0.0.1;
             deny all;
             proxy_pass ${RTMP_AUTH_URL};

--- a/nginx-transcoder/nginx.conf
+++ b/nginx-transcoder/nginx.conf
@@ -4,6 +4,8 @@ error_log /dev/stdout info;
 
 user nginx;
 
+limit_req_zone $binary_remote_addr zone=antiBruteForce:10m rate=1r/s;
+
 events {
     worker_connections 1024;
 }
@@ -13,6 +15,7 @@ rtmp {
         listen ${RTMP_PORT};
         chunk_size 4000;
         notify_method get;
+        limit_req zone=antiBruteForce;
 
         application live {
             live on;


### PR DESCRIPTION
This PR adds rate limiting to RTMP authentication. This prevents brute force attacks.

It limits requests to one per second. It allows for occasional bursts for up to 2 requests until, on avarage, the one per second is retained.
