### PR TITLE
Align track starts at the relay so DASH output carries no video edit list

### DIFF
--- a/nginx-transcoder/nginx-no-ssl.conf
+++ b/nginx-transcoder/nginx-no-ssl.conf
@@ -16,6 +16,13 @@ rtmp {
 
         application live {
             live on;
+            # Start the exec'd transcoder's input at a keyframe with audio held
+            # until video flows, so both tracks begin together. Without these,
+            # the subscriber gets audio up to one GOP before decodable video and
+            # ffmpeg records that skew as a leading empty edit on the video
+            # track, which desyncs players that drop edit lists in MSE.
+            wait_key on;
+            wait_video on;
             on_publish http://127.0.0.1/route_to_auth;
             exec ffmpeg -analyzeduration 10M -i rtmp://127.0.0.1/live/$name -strict -2 -c:a libopus -mapping_family 255 ${FFMPEG_FLAGS} -f dash /opt/data/dash/$name.mpd 2>>/tmp/nginx_rtmp_ffmpeg_log;
         }

--- a/nginx-transcoder/nginx.conf
+++ b/nginx-transcoder/nginx.conf
@@ -16,6 +16,13 @@ rtmp {
 
         application live {
             live on;
+            # Start the exec'd transcoder's input at a keyframe with audio held
+            # until video flows, so both tracks begin together. Without these,
+            # the subscriber gets audio up to one GOP before decodable video and
+            # ffmpeg records that skew as a leading empty edit on the video
+            # track, which desyncs players that drop edit lists in MSE.
+            wait_key on;
+            wait_video on;
             on_publish http://127.0.0.1/route_to_auth;
             exec ffmpeg -analyzeduration 10M -i rtmp://127.0.0.1/live/$name -strict -2 -c:a libopus -mapping_family 255 ${FFMPEG_FLAGS} -f dash /opt/data/dash/$name.mpd 2>>/tmp/nginx_rtmp_ffmpeg_log;
         }


### PR DESCRIPTION
## What this fixes

Earshot's DASH output desyncs audio and video by up to one GOP on Chromium and Safari whenever the transcoder (re)starts against a live stream. The offset is different after every restart, so it cannot be tuned away downstream.

## Mechanism

The transcoder is an nginx-rtmp `exec` ffmpeg that subscribes to the internal `live` application. A subscriber joining a live stream receives audio immediately, but no decodable video until the next keyframe arrives, up to one GOP later. ffmpeg therefore sees the video track start later than the audio track, and the DASH muxer faithfully records that skew as a leading empty edit (`elst`, `media_time = -1`) on the video track in the init segment.

Firefox applies that edit through MSE and stays in sync. Chromium and Safari do not apply it through MSE, so they present video early by the edit amount. The divergence is documented with a minimal repro here:

- https://github.com/mormegil6/mse-edit-list-repro (live demo on GitHub Pages)
- Chromium issue: https://issues.chromium.org/issues/537235698

Since most MSE players land on the dropping side, an Earshot deployment feeding dash.js/Shaka/hls.js on Chrome inherits an A/V desync that changes size on every encoder restart.

## Fix

Two stock nginx-rtmp directives on the `live` application, in both conf variants:

    wait_key on;     # relayed video starts at a keyframe
    wait_video on;   # audio is held until video flows

With these, both tracks genuinely start together, so there is no skew for the muxer to record and no edit list is written at all. Every player then behaves identically because there is nothing left to interpret.

## Measurements

Restart drill with a flash/beep marker contribution (flash and beep co-timed in the source; H.264 + 16-ch AAC, 2 s GOP, `-c:v copy` transcode):

| | video init edit list | decoded flash-vs-beep offset |
|---|---|---|
| without directives | leading empty edit on every join, 0.3 to 2.0 s (bounded by the GOP) | equals the edit size (tracks physically skewed) |
| with directives | `[(0, 0)]` on 20 of 20 runs | within 3 ms |

The second column is measured by decoding the output media directly (frame brightness and beep onset), independent of the edit list, which verifies the edit disappears because the tracks align, not because it was suppressed.

## Why not `-use_editlist 0`

Suppressing the edit list would leave the tracks skewed and delete the metadata Firefox correctly honours, desyncing Firefox to match the others. Aligning the track starts fixes the cause instead of hiding the symptom.

## Trade-off

`wait_video` delays the transcoder's input until the first keyframe after the join, so DASH output begins up to one GOP later than before. For a transcoding relay this is a startup cost only; steady-state latency is unchanged.
