### PR TITLE
Enable libvpx in ffmpeg so VP9 is actually available

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -85,6 +85,7 @@ RUN cd /tmp/FFmpeg-${FFMPEG_VERSION} && \
    --enable-small \
    --enable-libx264 \
    --enable-libopus \
+   --enable-libvpx \
    --disable-debug \
    --disable-doc \
    --disable-ffplay \


### PR DESCRIPTION
## What this fixes

`libvpx-dev` is installed as a build dependency in the `Dockerfile`, but ffmpeg's `./configure` enables only `--enable-libx264` and `--enable-libopus`. libvpx is therefore never compiled into the ffmpeg binary, so any `-c:v libvpx-vp9` transcode fails at runtime with:

```
Unknown encoder 'libvpx-vp9'
```

VP9 is a natural fit for Earshot's DASH/WebM output (and pairs with the Opus audio it already produces), but it is currently unreachable despite the dependency being present.

## Fix

Add `--enable-libvpx` to the ffmpeg configure, matching the already-installed `libvpx-dev`. One line, no new dependencies, no image-size change beyond the already-present runtime `libvpx`.

## Note on CI

The red `test` check is unrelated to this change — the workflow's `actions/cache@v2` is auto-rejected by GitHub, so `test` fails before it runs (`lint` still passes).
