### PR TITLE
Clear the DASH dir contents instead of rm -rf on the /opt/data mount

### DIFF
--- a/nginx-transcoder/entrypoint.sh
+++ b/nginx-transcoder/entrypoint.sh
@@ -37,7 +37,7 @@ if [ "$SSL_ENABLED" = true ] ; then
 
 
 
-	rm -rf /opt/data && mkdir -p /opt/data/dash && chown nginx /opt/data/dash && chmod 777 /opt/data/dash && mkdir -p /www && \
+	mkdir -p /opt/data/dash && find /opt/data/dash -mindepth 1 -delete && chown nginx /opt/data/dash && chmod 777 /opt/data/dash && mkdir -p /www && \
 	  envsubst "$(env | sed -e 's/=.*//' -e 's/^/\$/g')" < \
 	  /etc/nginx/nginx.conf.template > /etc/nginx/nginx.conf
 	### Send certbot Emission/Renewal to background
@@ -48,7 +48,7 @@ if [ "$SSL_ENABLED" = true ] ; then
 
 else
 	echo "Running Earshot without SSL (connections will be insecure)"
-	rm -rf /opt/data && mkdir -p /opt/data/dash && chown nginx /opt/data/dash && chmod 777 /opt/data/dash && mkdir -p /www && \
+	mkdir -p /opt/data/dash && find /opt/data/dash -mindepth 1 -delete && chown nginx /opt/data/dash && chmod 777 /opt/data/dash && mkdir -p /www && \
 	  envsubst "$(env | sed -e 's/=.*//' -e 's/^/\$/g')" < \
 	  /etc/nginx/nginx-no-ssl.conf.template > /etc/nginx/nginx.conf
 fi


### PR DESCRIPTION
## What this fixes

`nginx-transcoder/entrypoint.sh` resets segment state on every start with `rm -rf /opt/data` (in both the SSL and no-SSL branches). In the normal deployment `/opt/data` is the **mount point** for the DASH output volume (a named or bind volume), so this recursively deletes the contents of a mounted volume on each container start. That is:

- **unnecessary** - only the stale segment files need clearing, not the mount, and
- **risky** - it targets whatever the host has bound at `/opt/data`, not just the segment output.

## Fix

Clear only the segment directory contents, leaving the mount point intact:

```sh
mkdir -p /opt/data/dash && find /opt/data/dash -mindepth 1 -delete
```

This resets the DASH output exactly as before (an empty `/opt/data/dash` at startup) without `rm -rf`-ing the mount.

## Note on CI

The red `test` check is unrelated to this change - the workflow's `actions/cache@v2` is auto-rejected by GitHub, so `test` fails before it runs (`lint` still passes).
