### PR TITLE
nginx: emit relative redirects so a mapped host port survives directory redirects

### DIFF
--- a/nginx-transcoder/nginx-no-ssl.conf
+++ b/nginx-transcoder/nginx-no-ssl.conf
@@ -39,6 +39,13 @@ http {
     limit_req_status 401;
 
     server {
+        # Emit RELATIVE redirects. Otherwise nginx rebuilds a directory redirect
+        # (e.g. /webtools -> /webtools/) from its internal listen port, dropping
+        # any external mapped port when the container is published on a different
+        # port (docker -p 8081:80, or behind a reverse proxy / VPN bind) and
+        # sending the browser to the wrong URL.
+        absolute_redirect off;
+
         listen ${HTTP_PORT};
 
         location / {

--- a/nginx-transcoder/nginx.conf
+++ b/nginx-transcoder/nginx.conf
@@ -44,6 +44,13 @@ http {
     limit_req_status 401;
 
     server {
+        # Emit RELATIVE redirects. Otherwise nginx rebuilds a directory redirect
+        # (e.g. /webtools -> /webtools/) from its internal listen port, dropping
+        # any external mapped port when the container is published on a different
+        # port (docker -p 8081:80, or behind a reverse proxy / VPN bind) and
+        # sending the browser to the wrong URL.
+        absolute_redirect off;
+
         listen ${HTTP_PORT};
 
         listen 443 ssl;


### PR DESCRIPTION
### Problem

nginx builds a directory redirect (a request missing its trailing slash) as an **absolute** URL using its own internal listen port. When Earshot's transcoder container is published on a different host port (`docker run -p 8081:80`, or behind a reverse proxy / VPN bind), that external port is dropped:

```
$ curl -sI http://host:8081/webtools
HTTP/1.1 301 Moved Permanently
Location: http://host/webtools/      # port 80, wrong service
```

So `/webtools`, `/dash`, or any directory reached without a trailing slash sends the browser to the wrong place unless it happens to be served on port 80.

### Fix

`absolute_redirect off;` at the HTTP `server` level makes nginx emit a **relative** `Location`, which the browser resolves against the request URL and keeps the port:

```
$ curl -sI http://host:8081/webtools
HTTP/1.1 301 Moved Permanently
Location: /webtools/                 # relative, resolves to :8081/webtools/

$ curl -sIL http://host:8081/webtools | tail -1
HTTP/1.1 200 OK
```

One directive, applied to both `nginx.conf` and `nginx-no-ssl.conf`. No behaviour change for deployments served directly on 80/443.

### Verified

On a live deployment publishing the transcoder on `:8081` behind a Docker + Tailscale bind: before, `/webtools` 301'd to `http://host/webtools/` (dropped port); after, it 301s to a relative `/webtools/` and the follow-up request lands on `:8081` with 200.
