### PR TITLE
Allow building without --enable-nonfree for a redistributable image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -76,12 +76,17 @@ RUN cd /tmp/ && \
   wget https://github.com/EnvelopSound/ffmpeg/archive/${FFMPEG_VERSION}.tar.gz && \
   tar zxf ${FFMPEG_VERSION}.tar.gz && rm ${FFMPEG_VERSION}.tar.gz
 
+# --enable-nonfree gates GPL-incompatible libraries (e.g. libfdk_aac); this
+# build links none of them, so the flag is a no-op that only marks the binary
+# non-redistributable. Default on (behaviour unchanged); build with
+# --build-arg ENABLE_NONFREE=0 for a redistributable image.
+ARG ENABLE_NONFREE=1
 # Compile ffmpeg.
 RUN cd /tmp/FFmpeg-${FFMPEG_VERSION} && \
    ./configure \
    --enable-version3 \
    --enable-gpl \
-   --enable-nonfree \
+   $( [ "${ENABLE_NONFREE}" = "1" ] && printf '%s' '--enable-nonfree' ) \
    --enable-small \
    --enable-libx264 \
    --enable-libopus \


### PR DESCRIPTION
**Use case.** Publishing a pre-built Earshot image alongside a containerised HOA streaming stack. `--enable-nonfree` marks the resulting ffmpeg as non-redistributable, which blocks shipping the image through a public registry.

**The finding.** This build links no nonfree library. From `ffmpeg -buildconf` in the current image:

```
--enable-version3 --enable-gpl --enable-nonfree --enable-small --enable-libx264 --enable-libopus --enable-libvpx --disable-debug --disable-doc --disable-ffplay --extra-cflags=-I/opt/ffmpeg/include --extra-ldflags=-L/opt/ffmpeg/lib --extra-libs='-lpthread -lm' --prefix=/opt/ffmpeg
```

The only external codec libraries are libx264 (GPL), libopus (BSD) and libvpx (BSD). There is no libfdk_aac and no openssl. `--enable-nonfree` only relaxes a licence gate that nothing in the build uses, so removing it changes nothing except the licence stamp.

**The change.** `ARG ENABLE_NONFREE=1`. The default build is unchanged, flag included. `docker build --build-arg ENABLE_NONFREE=0` drops it and produces a plain GPLv3 binary (via libx264) that can be redistributed.

**Verification.** Built with `ENABLE_NONFREE=0`; the configure line loses only `--enable-nonfree`, and the full end-to-end pipeline (16-channel RTMP contribution in, live DASH out) passed identically:

```
[test-pipeline] PASS: first segment after 6s (deadline 20s), 14+14 chunks, 16-ch Opus + vp09 manifest OK
```

Stream probe of an encode made with the no-nonfree binary (the image ships no ffprobe, so this is ffmpeg reading back its own output): 16 discrete channels, hexadecagonal layout, no downmix, VP9 video:

```
Input #0, matroska,webm, from '/tmp/probe.webm':
  Duration: 00:00:02.01, start: -0.007000, bitrate: 1502 kb/s
    Stream #0:0: Video: vp9, yuv420p(tv), 640x320, SAR 1:1 DAR 2:1, 30 fps, 30 tbr, 1k tbn, 1k tbc (default)
    Stream #0:1: Audio: opus, 48000 Hz, hexadecagonal, fltp (default)
```
