### PR TITLE
Floor DASH suggestedPresentationDelay to avoid live-join gap-jumps

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -84,9 +84,11 @@ RUN cd /tmp/ && \
 # source instead.
 ARG DASH_SPD_FLOOR=30
 RUN cd /tmp/FFmpeg-${FFMPEG_VERSION} && \
+  case "${DASH_SPD_FLOOR}" in (""|*[!0-9]*) echo "DASH_SPD_FLOOR must be a non-negative integer" >&2; exit 1;; esac && \
   test "$(grep -c 'suggestedPresentationDelay=' libavformat/dashenc.c)" = "1" && \
+  grep -F 'suggestedPresentationDelay=' libavformat/dashenc.c | grep -F 'c->last_duration / AV_TIME_BASE' && \
   sed -i "/suggestedPresentationDelay=/s|c->last_duration / AV_TIME_BASE|FFMAX(c->last_duration / AV_TIME_BASE, ${DASH_SPD_FLOOR})|" libavformat/dashenc.c && \
-  grep -F "FFMAX(c->last_duration / AV_TIME_BASE, ${DASH_SPD_FLOOR})" libavformat/dashenc.c
+  grep -F 'suggestedPresentationDelay=' libavformat/dashenc.c | grep -F "FFMAX(c->last_duration / AV_TIME_BASE, ${DASH_SPD_FLOOR})"
 
 # --enable-nonfree gates GPL-incompatible libraries (e.g. libfdk_aac); this
 # build links none of them, so the flag is a no-op that only marks the binary

--- a/Dockerfile
+++ b/Dockerfile
@@ -76,6 +76,18 @@ RUN cd /tmp/ && \
   wget https://github.com/EnvelopSound/ffmpeg/archive/${FFMPEG_VERSION}.tar.gz && \
   tar zxf ${FFMPEG_VERSION}.tar.gz && rm ${FFMPEG_VERSION}.tar.gz
 
+# ffmpeg's DASH muxer hardcodes suggestedPresentationDelay to the last
+# segment duration, so a player joining live starts right at the edge and
+# can gap-jump into a segment that has not finished writing yet. No muxer
+# flag controls SPD directly (-target_latency is force-zeroed outside
+# LL-DASH mode, which WebM segments cannot use), so this floors it at the
+# source instead.
+ARG DASH_SPD_FLOOR=30
+RUN cd /tmp/FFmpeg-${FFMPEG_VERSION} && \
+  test "$(grep -c 'suggestedPresentationDelay=' libavformat/dashenc.c)" = "1" && \
+  sed -i "/suggestedPresentationDelay=/s|c->last_duration / AV_TIME_BASE|FFMAX(c->last_duration / AV_TIME_BASE, ${DASH_SPD_FLOOR})|" libavformat/dashenc.c && \
+  grep -F "FFMAX(c->last_duration / AV_TIME_BASE, ${DASH_SPD_FLOOR})" libavformat/dashenc.c
+
 # --enable-nonfree gates GPL-incompatible libraries (e.g. libfdk_aac); this
 # build links none of them, so the flag is a no-op that only marks the binary
 # non-redistributable. Default on (behaviour unchanged); build with


### PR DESCRIPTION
ffmpeg's DASH muxer hardcodes `suggestedPresentationDelay` to the last segment duration. A player that joins live therefore starts right at the live edge, and can seek/buffer into a segment the encoder has not finished writing yet.

No ffmpeg command-line flag sets SPD directly for this case: `-target_latency` is force-zeroed outside LL-DASH mode (`-streaming -write_prft`), and WebM segments cannot use LL-DASH. This patches `dashenc.c` at build time to floor SPD instead (default 30s, override with `--build-arg DASH_SPD_FLOOR`), which is the smallest change that reaches it.

The `sed` is guarded: it counts existing occurrences of `suggestedPresentationDelay=` first and fails the build if the surrounding code doesn't match what it expects, rather than silently doing nothing or patching the wrong spot.

Verified against the ffmpeg version currently pinned in this Dockerfile: image builds, the MPD's `suggestedPresentationDelay` reflects the floor, and playback is unaffected otherwise (segments are unchanged, only the manifest's own advertised join delay moves).

This is one of three small, independent patches from the same audit; I kept them as separate PRs (#dash-name, #max-message) so each can be reviewed and merged on its own.