### PR TITLE
Decouple the DASH manifest filename from the RTMP stream key

### DIFF
--- a/nginx-transcoder/entrypoint.sh
+++ b/nginx-transcoder/entrypoint.sh
@@ -4,6 +4,22 @@
 
 #Ensure we have folders available
 
+# DASH manifest filename. This is the only variable component of the ffmpeg
+# output path in either transcoder config (nginx-no-ssl.conf / nginx.conf), so
+# it is defaulted and validated here, before nginx starts and before either
+# envsubst call below. It must be exported: the envsubst whitelist is derived
+# from `env`, so an unexported value would leave the literal ${DASH_NAME} in
+# the rendered config, and ffmpeg would write a file nobody fetches. It is
+# read only from the container environment, never from the network, and
+# rejecting '.' and '/' makes '..' and absolute paths unrepresentable.
+DASH_NAME="${DASH_NAME:-stream}"
+case "$DASH_NAME" in
+    ''|*[!A-Za-z0-9_-]*)
+        echo "[earshot] DASH_NAME must be a non-empty [A-Za-z0-9_-]+ string (got: $DASH_NAME)" >&2
+        exit 1 ;;
+esac
+export DASH_NAME
+
 if [ "$SSL_ENABLED" = true ] ; then
 
 	if [ "$DOMAIN" = "" ]; then

--- a/nginx-transcoder/nginx-no-ssl.conf
+++ b/nginx-transcoder/nginx-no-ssl.conf
@@ -24,7 +24,10 @@ rtmp {
             wait_key on;
             wait_video on;
             on_publish http://127.0.0.1/route_to_auth;
-            exec ffmpeg -analyzeduration 10M -i rtmp://127.0.0.1/live/$name -strict -2 -c:a libopus -mapping_family 255 ${FFMPEG_FLAGS} -f dash /opt/data/dash/$name.mpd 2>>/tmp/nginx_rtmp_ffmpeg_log;
+            # $name (the publish name) stays on -i only; the manifest path uses
+            # ${DASH_NAME} instead, so the output location does not move when
+            # the publish name changes (e.g. a rotated stream key).
+            exec ffmpeg -analyzeduration 10M -i rtmp://127.0.0.1/live/$name -strict -2 -c:a libopus -mapping_family 255 ${FFMPEG_FLAGS} -f dash /opt/data/dash/${DASH_NAME}.mpd 2>>/tmp/nginx_rtmp_ffmpeg_log;
         }
     }
 }
@@ -91,6 +94,11 @@ http {
                 video/mp4 mp4;
             }
             root /opt/data;
+
+            # The manifest is written as ${DASH_NAME}.mpd, not <publish-name>.mpd,
+            # so a request for any other .mpd name would 404. Map it to the real
+            # one; segments are referenced relatively, so they resolve unchanged.
+            rewrite ^/dash/[^/]+\.mpd$ /dash/${DASH_NAME}.mpd break;
 
             # modify these if you need different CORS settings
             add_header Cache-Control no-cache;

--- a/nginx-transcoder/nginx.conf
+++ b/nginx-transcoder/nginx.conf
@@ -24,7 +24,11 @@ rtmp {
             wait_key on;
             wait_video on;
             on_publish http://127.0.0.1/route_to_auth;
-            exec ffmpeg -analyzeduration 10M -i rtmp://127.0.0.1/live/$name -strict -2 -c:a libopus -mapping_family 255 ${FFMPEG_FLAGS} -f dash /opt/data/dash/$name.mpd 2>>/tmp/nginx_rtmp_ffmpeg_log;
+            # $name (the publish name) stays on -i only; the manifest path uses
+            # ${DASH_NAME} instead, so the output location does not move when
+            # the publish name changes (e.g. a rotated stream key). Must stay
+            # identical to the exec line in nginx-no-ssl.conf.
+            exec ffmpeg -analyzeduration 10M -i rtmp://127.0.0.1/live/$name -strict -2 -c:a libopus -mapping_family 255 ${FFMPEG_FLAGS} -f dash /opt/data/dash/${DASH_NAME}.mpd 2>>/tmp/nginx_rtmp_ffmpeg_log;
         }
     }
 }
@@ -107,6 +111,11 @@ http {
                 video/mp4 mp4;
             }
             root /opt/data;
+
+            # The manifest is written as ${DASH_NAME}.mpd, not <publish-name>.mpd,
+            # so a request for any other .mpd name would 404. Map it to the real
+            # one; segments are referenced relatively, so they resolve unchanged.
+            rewrite ^/dash/[^/]+\.mpd$ /dash/${DASH_NAME}.mpd break;
 
             # modify these if you need different CORS settings
             add_header Cache-Control no-cache;


### PR DESCRIPTION
The manifest is currently named after `$name`, the RTMP publish name, which on most setups is (or embeds) the stream key. Rotating the key therefore moves the manifest to a new URL and breaks any page or bookmark pointing at the old one.

`DASH_NAME` is a new, independent env var for the manifest's base filename. It defaults to `stream`, is validated and exported in `entrypoint.sh` before nginx starts (before either `envsubst` call, since the whitelist `envsubst` uses is derived from `env`), and both transcoder configs write `${DASH_NAME}.mpd` instead of `$name.mpd`. `$name` stays on the ffmpeg `-i` side only, where it already has to match the publish name to self-pull the right stream.

Also updates the webtools `/dash` preview, which requests `/dash/<streamname>.mpd`: since the manifest is no longer named after the stream, that request would otherwise 404. A rewrite maps any `*.mpd` request under `/dash` to the real manifest; segments are referenced relatively, so they resolve unchanged regardless of the requested name.

Verified end to end against a live publish: manifest served at `/dash/${DASH_NAME}.mpd`, webtools preview still loads it under the old guessed name, and reconnecting under a different `$name` keeps writing the same manifest path.

One of three small, independent patches from the same audit, kept separate (along with #dash-spd-floor, #max-message) so each can be reviewed on its own merits.