### PR TITLE
Raise RTMP max_message so 4K keyframes are not dropped

### DIFF
--- a/nginx-transcoder/nginx-no-ssl.conf
+++ b/nginx-transcoder/nginx-no-ssl.conf
@@ -13,6 +13,10 @@ rtmp {
         listen ${RTMP_PORT};
         chunk_size 4000;
         notify_method get;
+        # 4K (and larger) H.264 keyframes can exceed nginx-rtmp's 1 MB default
+        # max_message, which drops the publish with "too big message" before
+        # ffmpeg ever sees a frame. Raise it well above a realistic keyframe size.
+        max_message 10M;
 
         application live {
             live on;

--- a/nginx-transcoder/nginx.conf
+++ b/nginx-transcoder/nginx.conf
@@ -13,6 +13,10 @@ rtmp {
         listen ${RTMP_PORT};
         chunk_size 4000;
         notify_method get;
+        # 4K (and larger) H.264 keyframes can exceed nginx-rtmp's 1 MB default
+        # max_message, which drops the publish with "too big message" before
+        # ffmpeg ever sees a frame. Raise it well above a realistic keyframe size.
+        max_message 10M;
 
         application live {
             live on;


### PR DESCRIPTION
nginx-rtmp's default `max_message` is 1 MB, sized for typical broadcast bitrates and GOPs, not 4K H.264 keyframes, which can exceed it. When that happens the relay drops the publish outright with "too big message" before the exec'd ffmpeg ever receives a frame, which looks like an ffmpeg or config problem but is actually the relay refusing the input.

Raised to 10 MB, comfortably above a realistic 4K keyframe at typical streaming bitrates, on the same `listen` block in both transcoder configs.

Verified against a 4K H.264 publish that reliably hit "too big message" at the 1 MB default and transcodes cleanly at 10 MB.

One of three small, independent patches from the same audit, kept separate (along with #dash-spd-floor, #dash-name) so each can be reviewed on its own merits.