### PR TITLE
Raise the yarn network timeout so slower hosts can build the webtools image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,7 +17,13 @@ COPY ./webtools/ /app
 ENV PATH /app/node_modules/.bin:$PATH
 
 # install and cache dependencies
-RUN yarn
+# yarn 1.x defaults --network-timeout to 30 s, and that ceiling covers the CPU
+# time yarn spends alongside each request, not transfer alone. On a slower build
+# host it expires mid-install and yarn reports it as "There appears to be trouble
+# with your network connection", which points at the wrong subsystem. Raised so
+# the install can finish; it costs nothing on a fast host, where the install
+# completes long before the ceiling is in reach.
+RUN yarn --network-timeout 600000
 #build the project for production
 RUN yarn build
 


### PR DESCRIPTION
On a slow enough build host the webtools stage fails at `RUN yarn` with `ESOCKETTIMEDOUT` and yarn's "There appears to be trouble with your network connection", which reads like a network fault and is not one.

yarn 1.x defaults `--network-timeout` to 30 s, and that ceiling covers the CPU time yarn spends alongside each request rather than transfer alone, so on a slow host it expires mid-install.

Measured on a Raspberry Pi 4 (arm64, native, not emulated), where the image would not build at all: the install needs **255 s** with yarn CPU-bound at 100-148 % throughout, while the package it dies on fetches in **0.23 s** from inside this same image. Network, DNS, emulation and memory pressure were each ruled out by measurement before anything was changed.

Raised to 600 s, which is inert on a fast host because the install finishes long before the ceiling matters, and x86_64 hosts therefore never hit this. Timeout alone is deliberately the whole change: at default concurrency the install takes 145 s, against 255 s with `--network-concurrency 1`, so the concurrency flag is both unnecessary and slower.

One of several small independent patches; kept separate so each can be judged on its own.