### PR TITLE
CI: make the workflows run again (actions v4, Compose v2, failure diagnostics)

### DIFF
--- a/.github/workflows/ci-ssl.yml
+++ b/.github/workflows/ci-ssl.yml
@@ -46,7 +46,7 @@ jobs:
         run: |
           cid=$(docker compose ps -aq nginx-rtmp) || true
           if [ -n "$cid" ]; then
-            docker cp "$cid":/tmp/nginx_rtmp_ffmpeg_log - 2>/dev/null | tar -xO || echo '(no transcoder log found)'
+            docker cp "$cid":/tmp/nginx_rtmp_ffmpeg_log - 2>/dev/null | tar -xO 2>/dev/null || echo '(no transcoder log found)'
           else
             echo '(nginx-rtmp container not found)'
           fi

--- a/.github/workflows/ci-ssl.yml
+++ b/.github/workflows/ci-ssl.yml
@@ -36,7 +36,7 @@ jobs:
 
 
       - name: Build and Test
-        run: docker-compose up --exit-code-from rtmp-tester
+        run: docker compose up --exit-code-from rtmp-tester
   lint:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/ci-ssl.yml
+++ b/.github/workflows/ci-ssl.yml
@@ -16,13 +16,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Create LFS file list
         run: git lfs ls-files -l | cut -d' ' -f1 | sort > .lfs-assets-id
 
       - name: Restore LFS cache
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         id: lfs-cache
         with:
           path: .git/lfs
@@ -41,7 +41,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
       - name: Install webtools modules
         run: cd webtools && yarn install
       - name: Run ESLint

--- a/.github/workflows/ci-ssl.yml
+++ b/.github/workflows/ci-ssl.yml
@@ -37,6 +37,19 @@ jobs:
 
       - name: Build and Test
         run: docker compose up --exit-code-from rtmp-tester
+
+      # The transcoder's ffmpeg writes its stderr to a file inside the
+      # container, so a failed run says only that the manifest is missing and
+      # never why. Surface it when the job fails.
+      - name: Transcoder log on failure
+        if: failure()
+        run: |
+          cid=$(docker compose ps -aq nginx-rtmp) || true
+          if [ -n "$cid" ]; then
+            docker cp "$cid":/tmp/nginx_rtmp_ffmpeg_log - 2>/dev/null | tar -xO || echo '(no transcoder log found)'
+          else
+            echo '(nginx-rtmp container not found)'
+          fi
   lint:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,7 +46,7 @@ jobs:
         run: |
           cid=$(docker compose ps -aq nginx-rtmp) || true
           if [ -n "$cid" ]; then
-            docker cp "$cid":/tmp/nginx_rtmp_ffmpeg_log - 2>/dev/null | tar -xO || echo '(no transcoder log found)'
+            docker cp "$cid":/tmp/nginx_rtmp_ffmpeg_log - 2>/dev/null | tar -xO 2>/dev/null || echo '(no transcoder log found)'
           else
             echo '(nginx-rtmp container not found)'
           fi

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,7 +36,7 @@ jobs:
 
 
       - name: Build and Test
-        run: docker-compose up --exit-code-from rtmp-tester
+        run: docker compose up --exit-code-from rtmp-tester
   lint:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,13 +16,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Create LFS file list
         run: git lfs ls-files -l | cut -d' ' -f1 | sort > .lfs-assets-id
 
       - name: Restore LFS cache
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         id: lfs-cache
         with:
           path: .git/lfs
@@ -41,7 +41,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
       - name: Install webtools modules
         run: cd webtools && yarn install
       - name: Run ESLint

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,6 +37,19 @@ jobs:
 
       - name: Build and Test
         run: docker compose up --exit-code-from rtmp-tester
+
+      # The transcoder's ffmpeg writes its stderr to a file inside the
+      # container, so a failed run says only that the manifest is missing and
+      # never why. Surface it when the job fails.
+      - name: Transcoder log on failure
+        if: failure()
+        run: |
+          cid=$(docker compose ps -aq nginx-rtmp) || true
+          if [ -n "$cid" ]; then
+            docker cp "$cid":/tmp/nginx_rtmp_ffmpeg_log - 2>/dev/null | tar -xO || echo '(no transcoder log found)'
+          else
+            echo '(nginx-rtmp container not found)'
+          fi
   lint:
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
CI has not run to completion on this repository since GitHub retired `actions/cache@v2`. The `test` job dies in seconds on every push and pull request, before it builds anything, so `master` has had no build or media-test coverage for a long time. This restores it.

Three commits, each one thing:

**1. Bump `actions/checkout` and `actions/cache` v2 to v4.** GitHub hard-fails any run using `cache@v2`, which is what kills the job at the "Restore LFS cache" step. `checkout@v2` is deprecated alongside it. Nothing else changes.

**2. Call the Compose v2 plugin.** With the job running again it reaches the build step and fails with `docker-compose: command not found` (exit 127): the standalone v1 binary is no longer on GitHub's `ubuntu-latest` images. `docker compose up --exit-code-from rtmp-tester` is the same command for the v2 plugin, and `--exit-code-from` is unchanged in v2.

**3. Print the transcoder log when the media test fails.** The transcoder's ffmpeg writes its stderr to `/tmp/nginx_rtmp_ffmpeg_log` inside the container, so a failing run reports only that the manifest is missing and never why. This step runs on failure only and is what made the diagnosis below possible.

### What this does and does not fix

With all three applied: **`lint` passes**, and `test` builds ffmpeg and nginx-rtmp from source, starts the stack, passes both auth tests, and accepts a real 16-channel RTMP publish. That is the whole pipeline working.

**It does not go green**, and I would rather flag that here than have it surprise you. The media test still fails at its final assertion, for a reason that predates these commits and is unrelated to them:

```
curl --fail http://nginx-rtmp:80/dash/stream1.mpd   ->  404
nginx-rtmp: open() "/opt/data/dash/stream1.mpd" failed (2: No such file or directory)
```

### Why, and why it is not a CI problem

The test pushes **audio only** (`tester/run-tests.sh`, `ffmpeg -i test.wav ... -c:a aac -ac 16 -f flv`), while the shipped default is **video passthrough** (`docker-compose.yml`, `FFMPEG_FLAGS=... -c:v copy`). So the transcoder is asked to copy a video stream from a source that has none. It prints its banner and then produces nothing: no `Input #0` line, no manifest, until nginx-rtmp kills it when the publisher disconnects.

The test and the default configuration disagree with each other, and CI being dead is why nobody saw it.

This is not specific to GitHub's runners. It reproduces on a local deployment, on an unrelated host, on a build of this same tree:

```sh
# audio-only, 16 channels, into a normally working stack
ffmpeg -f lavfi -i "sine=f=440:r=48000:d=40" -c:a aac -ac 16 -b:a 2048k \
       -f flv "rtmp://<host>:1935/live/<name>?token=<token>"
# -> no .mpd is ever written; the transcoder log ends at the ffmpeg banner
```

The same stack transcodes normally the moment the source carries video.

### What I have deliberately not done

I have not touched the test or the defaults. Either the test should push a source with video, or the flags used for that test should suit an audio-only source, and which of those is right depends on what the test was written to prove. That is your call rather than mine, so this pull request stays limited to making CI run and report.

Happy to follow up with whichever fix you prefer.
