### PR TITLE
Resume the AudioContext from the gain slider, not a window listener

### DIFF
--- a/webtools/src/GainSliderBox.js
+++ b/webtools/src/GainSliderBox.js
@@ -60,6 +60,9 @@ class GainSliderBox extends React.Component {
 
   setGain(channel, sliderValue) {
     const { gainNodes } = this.state;
+    if (audioContext.state === "suspended") {
+      audioContext.resume();
+    }
     if (videoPlayer.muted) {
       videoPlayer.muted = false;
     }

--- a/webtools/src/GainSliderBox.js
+++ b/webtools/src/GainSliderBox.js
@@ -61,7 +61,7 @@ class GainSliderBox extends React.Component {
   setGain(channel, sliderValue) {
     const { gainNodes } = this.state;
     if (audioContext.state === "suspended") {
-      audioContext.resume();
+      audioContext.resume().catch(() => {});
     }
     if (videoPlayer.muted) {
       videoPlayer.muted = false;


### PR DESCRIPTION
Same root cause #26 correctly diagnosed in 2021 (confirmed independently in #13): Chrome's autoplay policy leaves the AudioContext suspended until a user gesture, so webtools plays silently until something resumes it.

Different three-line fix: `GainSliderBox.setGain()` already only runs from the gain slider's `onChange`, which is itself a user gesture -- verified against the current source, `GainSlider.js` wires it straight to material-ui's Slider `onChange`. Resuming there needs no listener to register, no state flag to guard repeat calls, and nothing to tear down in `componentWillUnmount`. #26's version registers its listener inside `render()`, so React adds a new `window` listener on every re-render.

Supersedes #26, full credit to @gschian0 for the original diagnosis, which is what made this obvious.
