### PR TITLE
Force LF line endings for shell scripts, regardless of platform git config

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,3 +1,5 @@
+*.sh text eol=lf
+
 nginx-transcoder/bin-alpine/ffmpeg filter=lfs diff=lfs merge=lfs -text
 tester/bin/ffmpeg filter=lfs diff=lfs merge=lfs -text
 tester/resources/16chambixloop.wav filter=lfs diff=lfs merge=lfs -text


### PR DESCRIPTION
Windows checkouts with the common `core.autocrlf=true` setting silently convert `entrypoint.sh` (and the other shell scripts) to CRLF. Docker's build context reads the local working tree directly, so the CRLF-corrupted script gets baked into the image via `COPY`, and `#!/bin/sh\r` fails exec with `standard_init_linux.go:219: exec user process caused: no such file or directory` -- exactly the crash reported in #28. `.gitattributes` had no `eol` rule for `.sh` files at all. This forces LF for all shell scripts regardless of the checkout platform's line-ending config.

Fixes #28.
