### PR TITLE
webtools: uuid and yargs-parser were also webpack-dev-server-only

### DIFF
--- a/webtools/package.json
+++ b/webtools/package.json
@@ -87,6 +87,8 @@
     "**/node-notifier": "8.0.2",
     "**/flatted": "3.4.0",
     "**/tough-cookie": "4.1.3",
-    "**/tmp": "0.2.4"
+    "**/tmp": "0.2.4",
+    "**/uuid": "11.1.1",
+    "**/yargs/yargs-parser": "13.1.2"
   }
 }

--- a/webtools/yarn.lock
+++ b/webtools/yarn.lock
@@ -11075,15 +11075,10 @@ utils-merge@1.0.1:
   resolved "https://registry.yarnpkg.com/utils-merge/-/utils-merge-1.0.1.tgz#9f95710f50a267947b2ccc124741c1028427e713"
   integrity sha512-pMZTvIkT1d+TFGvDOqodOclx0QWkkgi6Tdoa8gC8ffGAAqz9pzPTZWAybbsHHoED/ztMtkv/VoYTYyShUn81hA==
 
-uuid@^3.3.2:
-  version "3.4.0"
-  resolved "https://registry.yarnpkg.com/uuid/-/uuid-3.4.0.tgz#b23e4358afa8a202fe7a100af1f5f883f02007ee"
-  integrity sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==
-
-uuid@^8.3.0, uuid@^8.3.2:
-  version "8.3.2"
-  resolved "https://registry.yarnpkg.com/uuid/-/uuid-8.3.2.tgz#80d5b5ced271bb9af6c445f21a1a04c606cefbe2"
-  integrity sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==
+uuid@11.1.1, uuid@^3.3.2, uuid@^8.3.0, uuid@^8.3.2:
+  version "11.1.1"
+  resolved "https://registry.yarnpkg.com/uuid/-/uuid-11.1.1.tgz#f6d81d2e1c65d00762e5e29b16c5d2d995e208ad"
+  integrity sha512-vIYxrBCC/N/K+Js3qSN88go7kIfNPssr/hHCesKCQNAjmgvYS2oqr69kIufEG+O4+PfezOH4EbIeHCfFov8ZgQ==
 
 v8-compile-cache@^2.0.3:
   version "2.1.0"
@@ -11635,15 +11630,7 @@ yaml@^1.7.2:
   resolved "https://registry.yarnpkg.com/yaml/-/yaml-1.10.3.tgz#76e407ed95c42684fb8e14641e5de62fe65bbcb3"
   integrity sha512-vIYeF1u3CjlhAFekPPAk2h/Kv4T3mAkMox5OymRiJQB0spDP10LHvt+K7G9Ny6NuuMAb25/6n1qyUjAcGNf/AA==
 
-yargs-parser@^11.1.1:
-  version "11.1.1"
-  resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-11.1.1.tgz#879a0865973bca9f6bab5cbdf3b1c67ec7d3bcf4"
-  integrity sha512-C6kB/WJDiaxONLJQnF8ccx9SEeoTTLek8RVbaOIsrAUS8VrBEXfmeSnCZxygc+XC2sNMBIwOOnfcxiynjHsVSQ==
-  dependencies:
-    camelcase "^5.0.0"
-    decamelize "^1.2.0"
-
-yargs-parser@^13.1.2:
+yargs-parser@13.1.2, yargs-parser@^11.1.1, yargs-parser@^13.1.2:
   version "13.1.2"
   resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-13.1.2.tgz#130f09702ebaeef2650d54ce6e3e5706f7a4fb38"
   integrity sha512-3lbsNRf/j+A4QuSZfDRA7HRSfWrzO0YjqTJd5kjAq37Zep1CEgaYmrH9Q3GwPiB9cHyd1Y1UwggGhJGoxipbzg==


### PR DESCRIPTION
Second pass over uuid and yargs-parser after realizing fixing earlier packages can expose more of these: node-notifier (patched in #76) is one of uuid's four requesters, and node-notifier was already proven jest-only in that same PR. Traced the other three the same way #76 traced everything else:

- uuid's four requester chains: node-notifier@8.0.2 (jest-only, already proven), sockjs@0.3.24 and webpack-log@2.0.0 (both required only by webpack-dev-server, itself start.js-only), and request@2.88.2 (dashjs's own dependency). Checked whether uuid's actual code reaches the shipped bundle by grepping the real build output for uuid-formatted strings: the only matches are dash.js's own hardcoded ClearKey DRM key-system identifiers (standard EME constants), not the uuid package - it isn't there.
- yargs-parser's vulnerable stanza is required by yargs@12.0.5, which in turn is required only by webpack-dev-server - same dead chain as the rest of that tier. Consolidated to 13.1.2, the version already used elsewhere in this lockfile via jest's own yargs@13.3.2.

Verified: yarn install converges to one stanza per package with zero drift, yarn lint clean, production build succeeds, stage-0 rebuilds clean under --no-cache using the Dockerfile's real instructions, and the output bundle's content hash (2.21421893.chunk.js) is unchanged from every prior verification in this chain (#74 through #76) - confirming neither package reaches anything that ships.
