### PR TITLE
webtools: immer (critical), serialize-javascript DoS - both surfaced by #79 itself

### DIFF
--- a/webtools/package.json
+++ b/webtools/package.json
@@ -96,6 +96,7 @@
     "**/svgo": "2.8.3",
     "**/fast-xml-parser": "5.7.0",
     "**/react-dev-utils": "11.0.4",
-    "**/serialize-javascript": "7.0.3"
+    "**/serialize-javascript": "7.1.0",
+    "**/react-dev-utils/immer": "9.0.6"
   }
 }

--- a/webtools/yarn.lock
+++ b/webtools/yarn.lock
@@ -5684,10 +5684,10 @@ immediate@~3.0.5:
   resolved "https://registry.yarnpkg.com/immediate/-/immediate-3.0.6.tgz#9db1dbd0faf8de6fbe0f5dd5e56bb606280de69b"
   integrity sha1-nbHb0Pr43m++D13V5Wu2BigN5ps=
 
-immer@8.0.1:
-  version "8.0.1"
-  resolved "https://registry.yarnpkg.com/immer/-/immer-8.0.1.tgz#9c73db683e2b3975c424fb0572af5889877ae656"
-  integrity sha512-aqXhGP7//Gui2+UrEtvxZxSquQVXTpZ7KDxfCcKAF3Vysvw0CViVaW9RZ1j1xlIYqaaaipBoqdqeibkc18PNvA==
+immer@8.0.1, immer@9.0.6:
+  version "9.0.6"
+  resolved "https://registry.yarnpkg.com/immer/-/immer-9.0.6.tgz#7a96bf2674d06c8143e327cbf73539388ddf1a73"
+  integrity sha512-G95ivKpy+EvVAnAab4fVa4YGYn24J1SpEktnJX7JJ45Bd7xqME/SCplFzYFmTbrkwZbQ4xJK1xMTUYBkN6pWsQ==
 
 import-cwd@^2.0.0:
   version "2.1.0"
@@ -9926,10 +9926,10 @@ send@~0.19.0, send@~0.19.1:
     range-parser "~1.2.1"
     statuses "~2.0.2"
 
-serialize-javascript@7.0.3, serialize-javascript@^2.1.2:
-  version "7.0.3"
-  resolved "https://registry.yarnpkg.com/serialize-javascript/-/serialize-javascript-7.0.3.tgz#c92008d8a21bc7b2307c2e885a4bd0f03b2aee6c"
-  integrity sha512-h+cZ/XXarqDgCjo+YSyQU/ulDEESGGf8AMK9pPNmhNSl/FzPl6L8pMp1leca5z6NuG6tvV/auC8/43tmovowww==
+serialize-javascript@7.1.0, serialize-javascript@^2.1.2:
+  version "7.1.0"
+  resolved "https://registry.yarnpkg.com/serialize-javascript/-/serialize-javascript-7.1.0.tgz#9e462c5c6dec5dbc8b55d90c52a4ad6aff985b9f"
+  integrity sha512-RNEqWOyhhUQYN9V1GfHwu9AR/g+NTciH6Z5u3/no6X3/w+04J2lVDL+svFQVXgXrEGBMG2puMVN3gq2SNGuTGw==
 
 serve-index@^1.9.1:
   version "1.9.1"


### PR DESCRIPTION
Two new alerts appeared within a minute of #79 merging - the exact same pattern as `fast-xml-parser` following #78, where a version bump's own transitive tree (or a fresh advisory) lands right after the change that triggered it.

**immer** (new entry, 9.0.6): two alerts (HIGH + CRITICAL, prototype pollution, `>=7.0.0 <9.0.6`). This is `react-dev-utils@11.0.4`'s own dependency, introduced the same way `fast-xml-parser` was - not independently added here. Traced to its one real call site: `react-scripts/scripts/utils/verifyTypeScriptSetup.js` requires `react-dev-utils/immer` and calls it at line 160 - but that function's own entry point returns immediately when no `tsconfig.json` exists and zero `.ts`/`.tsx` files are found under `src/`, both true for this JS-only app. `build.js` calls `verifyTypeScriptSetup()` unconditionally, so the function *does* run on every build, but its internal TypeScript-detection gate - the same one that already excludes `ForkTsCheckerWebpackPlugin` - returns before the code ever reaches immer. Forced to the patched version anyway rather than left as another documented exclusion, since nothing here depends on immer's behavior and a clean close is simpler.

**serialize-javascript** (7.0.3 → 7.1.0): one new alert (MODERATE, CPU exhaustion DoS via crafted array-like objects, `>=5.0.0 <7.0.5`) that #79's 7.0.3 sits inside. This is the package already established as unconditionally, actively reachable (`terser-webpack-plugin`'s core minification dispatch, including a call site feeding output into `new Function(...)`), so the same rigor applies again: bumped past the patched floor, re-verified the build produces the identical shipped bundle content hash already established as stable since #70 - not just "the build succeeds," but the same bytes ship.

Verified: `package.json` is valid JSON, `yarn install` converges both packages to single deduped stanzas, `yarn lint` is clean, `yarn build` succeeds with the shipped bundle's content hash unchanged, and an uncached `docker build` against the real Dockerfile's build stage succeeds cleanly.
