### PR TITLE
Build FFmpeg from a current release (n7.1) instead of the 2020 fork

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -40,7 +40,7 @@ FROM alpine:3.11
 ARG NGINX_VERSION=1.15.1
 ARG NGINX_RTMP_VERSION=1.2.1
 
-ARG FFMPEG_VERSION=earshot-v0.1
+ARG FFMPEG_VERSION=n7.1
 
 ARG PREFIX=/opt/ffmpeg
 ARG LD_LIBRARY_PATH=/opt/ffmpeg/lib
@@ -86,7 +86,7 @@ RUN apk add --update \
 
 # Get FFmpeg source.
 RUN cd /tmp/ && \
-  wget https://github.com/EnvelopSound/ffmpeg/archive/${FFMPEG_VERSION}.tar.gz && \
+  wget -O ${FFMPEG_VERSION}.tar.gz https://github.com/FFmpeg/FFmpeg/archive/refs/tags/${FFMPEG_VERSION}.tar.gz && \
   tar zxf ${FFMPEG_VERSION}.tar.gz && rm ${FFMPEG_VERSION}.tar.gz
 
 # ffmpeg's DASH muxer hardcodes suggestedPresentationDelay to the last


### PR DESCRIPTION
Two lines in the Dockerfile: build ffmpeg from the upstream `n7.1` release tag instead of `EnvelopSound/ffmpeg` at `earshot-v0.1`, which reports `ffmpeg version 4.3.git ... Copyright (c) 2000-2020` and is frozen around 2021-04, roughly 26k commits behind upstream.

The fork exists for one thing: PCE-aware AAC, so a 16-channel (hexadecagonal) OBS Music Edition contribution survives the RTMP leg. Six years on, that is no longer a reason to carry a fork, and both halves check out against real builds rather than assumption:

- **Decode of 16-ch PCE AAC is upstream.** Earshot's actual job, decode the contribution AAC and re-encode to 16-ch Opus for DASH, runs unmodified on stock ffmpeg.
- **Encode of 16-ch AAC is native in n7.1.** `libavcodec/aacenc.c`'s `aac_pce_configs[]` carries `AV_CHANNEL_LAYOUT_HEXADECAGONAL` at the n7.1 tag. It was dropped from `master` around `c92c6cbf` during the channel-layout API rework, which is a separate upstream regression and the reason this targets the n7.1 release specifically rather than a newer one.

What the move buys, beyond retiring a third-party fork last touched in 2022: it closes roughly six years of CVE and hardening work on exactly the demuxer and decoder paths that meet contribution bytes (`aacdec`, `flvdec`, `mpegts`), and it gains modern muxer behaviour. The one that matters in practice is Opus-in-fMP4 for DASH: under `-dash_segment_type mp4` the audio and the copied-through H.264 video share a single fMP4 container, rather than the mixed fMP4-video / WebM-audio manifest the 2020 muxer forces, which FFmpeg-based players cannot demux without stuttering.

The one local patch this Dockerfile carries, the DASH `suggestedPresentationDelay` floor `sed` on `libavformat/dashenc.c`, applies to n7.1 with no change: the target line and its `c->last_duration / AV_TIME_BASE` expression are byte-identical at the tag, and the build-time post-check that guards it still passes.

Verified on real builds of this image, amd64 and a native arm64 build on a Raspberry Pi 4: ffmpeg reports 7.1; it encodes 16-ch hexadecagonal AAC and decodes it back; it decodes 16-ch AAC to 16-ch Opus (the live transcode); it produces Opus-in-fMP4 DASH under `-dash_segment_type mp4`; the SPD floor works, with a live manifest showing `PT30S`; a full synthetic RTMP contribution to 16-ch Opus DASH pipeline passes with all sixteen channels in their correct slots; and the Opus-in-fMP4 output plays in-browser on Chrome and Firefox through dash.js/MSE with all sixteen channels decoding.