### PR TITLE
Verify FFmpeg against a pinned SHA-256 from the signed release tarball

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -40,7 +40,8 @@ FROM alpine:3.11
 ARG NGINX_VERSION=1.15.1
 ARG NGINX_RTMP_VERSION=1.2.1
 
-ARG FFMPEG_VERSION=n7.1
+ARG FFMPEG_VERSION=7.1
+ARG FFMPEG_SHA256=40973d44970dbc83ef302b0609f2e74982be2d85916dd2ee7472d30678a7abe6
 
 ARG PREFIX=/opt/ffmpeg
 ARG LD_LIBRARY_PATH=/opt/ffmpeg/lib
@@ -68,6 +69,7 @@ RUN apk add --update \
   pkgconfig \
   rtmpdump-dev \
   wget \
+  xz \
   x264-dev \
   x265-dev \
   yasm \
@@ -84,10 +86,17 @@ RUN apk add --update \
   inotify-tools \
   certbot
 
-# Get FFmpeg source.
+# Get FFmpeg source from the ffmpeg.org release tarball and verify it against a
+# pinned SHA-256. The release .tar.xz is a signed, immutable artifact; GitHub's
+# /archive/refs/tags/ tarballs are generated on demand and their bytes (hence
+# hash) have changed before, so a pin is only meaningful against the release
+# tarball, not the archive URL. This hash is the one FFmpeg's release signing
+# key (FCF9 86EA 15E6 E293 A564 4F10 B432 2F04 D676 58D8) signs for 7.1; a
+# mismatch aborts the build rather than compiling unexpected source.
 RUN cd /tmp/ && \
-  wget -O ${FFMPEG_VERSION}.tar.gz https://github.com/FFmpeg/FFmpeg/archive/refs/tags/${FFMPEG_VERSION}.tar.gz && \
-  tar zxf ${FFMPEG_VERSION}.tar.gz && rm ${FFMPEG_VERSION}.tar.gz
+  wget -O ffmpeg-${FFMPEG_VERSION}.tar.xz https://ffmpeg.org/releases/ffmpeg-${FFMPEG_VERSION}.tar.xz && \
+  echo "${FFMPEG_SHA256}  ffmpeg-${FFMPEG_VERSION}.tar.xz" | sha256sum -c - && \
+  xz -dc ffmpeg-${FFMPEG_VERSION}.tar.xz | tar -xf - && rm ffmpeg-${FFMPEG_VERSION}.tar.xz
 
 # ffmpeg's DASH muxer hardcodes suggestedPresentationDelay to the last
 # segment duration, so a player joining live starts right at the edge and
@@ -96,7 +105,7 @@ RUN cd /tmp/ && \
 # LL-DASH mode, which WebM segments cannot use), so this floors it at the
 # source instead.
 ARG DASH_SPD_FLOOR=30
-RUN cd /tmp/FFmpeg-${FFMPEG_VERSION} && \
+RUN cd /tmp/ffmpeg-${FFMPEG_VERSION} && \
   case "${DASH_SPD_FLOOR}" in (""|*[!0-9]*) echo "DASH_SPD_FLOOR must be a non-negative integer" >&2; exit 1;; esac && \
   test "$(grep -c 'suggestedPresentationDelay=' libavformat/dashenc.c)" = "1" && \
   grep -F 'suggestedPresentationDelay=' libavformat/dashenc.c | grep -F 'c->last_duration / AV_TIME_BASE' && \
@@ -109,7 +118,7 @@ RUN cd /tmp/FFmpeg-${FFMPEG_VERSION} && \
 # --build-arg ENABLE_NONFREE=0 for a redistributable image.
 ARG ENABLE_NONFREE=1
 # Compile ffmpeg.
-RUN cd /tmp/FFmpeg-${FFMPEG_VERSION} && \
+RUN cd /tmp/ffmpeg-${FFMPEG_VERSION} && \
    ./configure \
    --enable-version3 \
    --enable-gpl \
@@ -127,7 +136,7 @@ RUN cd /tmp/FFmpeg-${FFMPEG_VERSION} && \
    --prefix="${PREFIX}" && \
     make && make install && make distclean
 
-#COPY /tmp/FFmpeg-${FFMPEG_VERSION}/build/ffmpeg /usr/local/bin/
+#COPY /tmp/ffmpeg-${FFMPEG_VERSION}/build/ffmpeg /usr/local/bin/
 
 # Get nginx source.
 RUN cd /tmp && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -40,6 +40,15 @@ FROM alpine:3.11
 ARG NGINX_VERSION=1.15.1
 ARG NGINX_RTMP_VERSION=1.2.1
 
+# Do not bump past n8.1 without re-checking 16-channel AAC encoding. n9.0
+# removed AV_CHANNEL_LAYOUT_HEXADECAGONAL from aac_pce_configs[] in
+# libavcodec/aacenc.c (c92c6cbf19), and with it the only PCE config able to
+# encode any layout above 8 channels. The RTMP contribution leg carries 16-ch
+# AAC with a PCE from OBS Music Edition, so on n9.0 that leg dies at encoder
+# init with "Unsupported channel layout". Note this is a RUNTIME failure, not
+# a build failure: the image still builds clean and only breaks when a
+# 16-channel stream actually arrives. Verified present at n7.0 through n8.1,
+# absent at n9.0 and master.
 ARG FFMPEG_VERSION=7.1
 ARG FFMPEG_SHA256=40973d44970dbc83ef302b0609f2e74982be2d85916dd2ee7472d30678a7abe6
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -40,15 +40,16 @@ FROM alpine:3.11
 ARG NGINX_VERSION=1.15.1
 ARG NGINX_RTMP_VERSION=1.2.1
 
-# Do not bump past n8.1 without re-checking 16-channel AAC encoding. n9.0
+# Do not bump past 8.1 without re-checking 16-channel AAC encoding. Release 9.0
 # removed AV_CHANNEL_LAYOUT_HEXADECAGONAL from aac_pce_configs[] in
-# libavcodec/aacenc.c (c92c6cbf19), and with it the only PCE config able to
-# encode any layout above 8 channels. The RTMP contribution leg carries 16-ch
-# AAC with a PCE from OBS Music Edition, so on n9.0 that leg dies at encoder
-# init with "Unsupported channel layout". Note this is a RUNTIME failure, not
-# a build failure: the image still builds clean and only breaks when a
-# 16-channel stream actually arrives. Verified present at n7.0 through n8.1,
-# absent at n9.0 and master.
+# libavcodec/aacenc.c (commit c92c6cbf19), and with it the only PCE config able
+# to encode any layout above 8 channels. The RTMP contribution leg carries 16-ch
+# AAC with a PCE from OBS Music Edition, so on 9.0 that leg dies at encoder init
+# with "Unsupported channel layout". Note this is a RUNTIME failure, not a build
+# failure: the image still builds clean and only breaks when a 16-channel stream
+# actually arrives. Verified present in 7.0 through 8.1, absent from 9.0 onward.
+# Version numbers here are release names, matching FFMPEG_VERSION and the
+# ffmpeg.org tarball; the corresponding git tags carry an "n" prefix (n8.1).
 ARG FFMPEG_VERSION=7.1
 ARG FFMPEG_SHA256=40973d44970dbc83ef302b0609f2e74982be2d85916dd2ee7472d30678a7abe6
 


### PR DESCRIPTION
A focused follow-up to #81. That PR moved the build to the upstream 7.1 source but fetched it from GitHub's `/archive/refs/tags/` URL, a tarball generated on demand whose bytes are not stable (GitHub has changed archive compression before), so there is nothing a checksum could meaningfully pin against. This switches the source to the ffmpeg.org release artifact and verifies it against a pinned SHA-256 before anything is extracted or compiled.

What changes:

- **Source**: `https://ffmpeg.org/releases/ffmpeg-7.1.tar.xz` instead of the GitHub archive URL. This is the signed, immutable release tarball, the same artifact ffmpeg.org publishes a GPG signature for.
- **Verification**: the download is checked against a pinned SHA-256 (`echo "<hash>  <file>" | sha256sum -c -`) before extraction. A mismatch aborts the build rather than silently compiling unexpected source. The pinned hash is the one FFmpeg's release signing key (`FCF9 86EA 15E6 E293 A564 4F10 B432 2F04 D676 58D8`) signs for 7.1; I verified that signature against the key before hardcoding the hash.
- **Container**: the release is `.tar.xz`, so the build adds `xz` to the Alpine build deps and decompresses with `xz -dc | tar`. The extract directory is lowercase `ffmpeg-7.1` (release convention) rather than `FFmpeg-n7.1` (GitHub archive convention), updated in the two `cd` references and the one commented-out `COPY`.

`FFMPEG_VERSION` goes `n7.1` -> `7.1` to match the release naming, and a `FFMPEG_SHA256` arg holds the pin. Everything downstream is unchanged: the DASH `suggestedPresentationDelay` floor `sed` and its build-time post-check, the `configure` flags, the compile. It is the same 7.1 source, fetched from the release channel and verified.

One maintenance note for whoever bumps ffmpeg next: the pin is version-locked, so a change to `FFMPEG_VERSION` must come with a matching `FFMPEG_SHA256`, or the build stops at the checksum step. That is the guard doing its job rather than a regression, but it is worth stating so the failure is expected rather than surprising.

Verified on real builds of this image, amd64 and a native arm64 build on a Raspberry Pi 4: the checksum check passes on both arches (`ffmpeg-7.1.tar.xz: OK`), the `.tar.xz` decompresses and the image builds to completion, and the SPD-floor patch still applies byte-for-byte. A deliberately corrupted pin was also tested: the build fails at the `sha256sum -c` step with `1 computed checksum did NOT match`, before the download is extracted and before ffmpeg is compiled, and no image is produced.
