### PR TITLE
webtools: record why the AudioContext resume is needed, with the measurement

### DIFF
--- a/webtools/src/GainSliderBox.js
+++ b/webtools/src/GainSliderBox.js
@@ -60,6 +60,18 @@ class GainSliderBox extends React.Component {
 
   setGain(channel, sliderValue) {
     const { gainNodes } = this.state;
+    // Video.js constructs the AudioContext at module-import time, which is
+    // before any user gesture, so browsers with an autoplay policy hand it back
+    // "suspended" and the whole graph is stopped. Unmuting the element and
+    // raising a gain then change nothing audible, which is exactly what a user
+    // dragging this slider experiences: no sound, and no clue why.
+    //
+    // Measured on a live 16-channel stream, each step added alone (RMS into
+    // ctx.destination): gain up 0.0, + element unmuted 0.0, + resume() 5.6e-4.
+    // Only the resume makes it audible.
+    //
+    // This is the right place for it: setGain runs from an actual user gesture,
+    // which is precisely when a browser will allow the context to start.
     if (audioContext.state === "suspended") {
       audioContext.resume().catch(() => {});
     }

--- a/webtools/src/GainSliderBox.js
+++ b/webtools/src/GainSliderBox.js
@@ -63,8 +63,8 @@ class GainSliderBox extends React.Component {
     // Video.js constructs the AudioContext at module-import time, which is
     // before any user gesture, so browsers with an autoplay policy hand it back
     // "suspended" and the whole graph is stopped. Unmuting the element and
-    // raising a gain then change nothing audible, which is exactly what a user
-    // dragging this slider experiences: no sound, and no clue why.
+    // raising a gain do nothing audible on their own, which is exactly what a
+    // user dragging this slider experiences: no sound, and no clue why.
     //
     // Measured on a live 16-channel stream, each step added alone (RMS into
     // ctx.destination): gain up 0.0, + element unmuted 0.0, + resume() 5.6e-4.


### PR DESCRIPTION
The `audioContext.resume()` in `setGain` landed in #64. This adds the reasoning directly above it.

video.js constructs the AudioContext at module-import time, before any user gesture, so a browser enforcing an autoplay policy hands it back `suspended` and the whole graph is stopped. Unmuting the element and raising a gain then change nothing audible, which is exactly what a user dragging the slider experiences: no sound and no clue why.

Measured on a live 16-channel stream, each step added alone (RMS into `ctx.destination`):

| step | RMS |
|---|---|
| gain up | 0.0 |
| + element unmuted | 0.0 |
| + `resume()` | 5.6e-4 |

Only the resume makes it audible.

Comment only, no behaviour change. The reason for sending it: a bare `resume()` with no explanation reads as defensive boilerplate and invites removal, and the next person to hit this would have to measure it again.