### PR TITLE
nginxInfo: report dashName alongside ffmpegFlags

### DIFF
--- a/nginx-transcoder/nginx-no-ssl.conf
+++ b/nginx-transcoder/nginx-no-ssl.conf
@@ -143,7 +143,7 @@ http {
 
         # static nginx runtime info served to webtools
         location /nginxInfo {
-            return 200 '{"ffmpegFlags":"${FFMPEG_FLAGS}"}';
+            return 200 '{"ffmpegFlags":"${FFMPEG_FLAGS}","dashName":"${DASH_NAME}"}';
         }
 
         location /webtools {

--- a/nginx-transcoder/nginx-no-ssl.conf
+++ b/nginx-transcoder/nginx-no-ssl.conf
@@ -143,6 +143,7 @@ http {
 
         # static nginx runtime info served to webtools
         location /nginxInfo {
+            default_type application/json;
             return 200 '{"ffmpegFlags":"${FFMPEG_FLAGS}","dashName":"${DASH_NAME}"}';
         }
 

--- a/nginx-transcoder/nginx.conf
+++ b/nginx-transcoder/nginx.conf
@@ -160,6 +160,7 @@ http {
 
         # static nginx runtime info served to webtools
         location /nginxInfo {
+            default_type application/json;
             return 200 '{"ffmpegFlags":"${FFMPEG_FLAGS}","dashName":"${DASH_NAME}"}';
         }
 

--- a/nginx-transcoder/nginx.conf
+++ b/nginx-transcoder/nginx.conf
@@ -160,7 +160,7 @@ http {
 
         # static nginx runtime info served to webtools
         location /nginxInfo {
-            return 200 '{"ffmpegFlags":"${FFMPEG_FLAGS}"}';
+            return 200 '{"ffmpegFlags":"${FFMPEG_FLAGS}","dashName":"${DASH_NAME}"}';
         }
 
         location /webtools {


### PR DESCRIPTION
`/nginxInfo` exists to tell a client how this server is configured, and currently returns only `ffmpegFlags`.

The manifest is written to `${DASH_NAME}.mpd`. That name is configurable and need not match the publish name, so a client has no reliable way to work out which URL to request. This adds the field it would need:

```json
{"ffmpegFlags":"...","dashName":"..."}
```

One field, added to both `nginx.conf` and `nginx-no-ssl.conf` so the two stay identical.